### PR TITLE
fix(headers): HACKATHON-5 - Move the adding of headers to each indivi…

### DIFF
--- a/internal/sort/sort.go
+++ b/internal/sort/sort.go
@@ -29,8 +29,8 @@ func sortFiles(files []string) (map[string][]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not combine files: %w", err)
 		}
-
-		filesToSort = append(filesToSort, combinedFile)
+		// Reset filesToSort to only contain combinedFile.
+		filesToSort = []string{combinedFile}
 	}
 
 	output := map[string][]byte{}


### PR DESCRIPTION
Fixes the duplication of headers when files are grouped

Tested with:
`./bin/tfsort sort ./internal/sort/testdata/multiple_files_with_headers/unsorted -d -o scratch/tmp_single -r --config ./internal/sort/testdata/multiple_files_with_headers/.tfsort.yaml > scratch/test_single.txt 2>&1`

AND

`./bin/tfsort sort ./internal/sort/testdata/multiple_files_with_headers/unsorted -g -d -o scratch/tmp_grouped -r --config ./internal/sort/testdata/multiple_files_with_headers/.tfsort.yaml > scratch/test_grouped.txt 2>&1`
