### PR TITLE
feat(inline): Add -i, --inline flag for sort command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Flags:
   -e, --has-header              the input files have a header
   -p, --header-pattern string   the header pattern to find the header in the input files
   -h, --help                    help for sort
+  -i, --inline                  sort the resources in the input file(s) in place
   -k, --keep-header             keep the header matched in the header pattern in the output files
   -o, --output-dir string       output the results to a specific folder
   -r, --remove-comments         remove comments in the sorted file(s)

--- a/internal/sort/cmd.go
+++ b/internal/sort/cmd.go
@@ -32,6 +32,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVarP(&flags.HasHeader, "has-header", "e", false, "the input files have a header")
 	cmd.PersistentFlags().StringVarP(&flags.HeaderPattern, "header-pattern", "p", "", "the header pattern to find the header in the input files")
 	cmd.PersistentFlags().BoolVarP(&flags.KeepHeader, "keep-header", "k", false, "keep the header matched in the header pattern in the output files")
+	cmd.PersistentFlags().BoolVarP(&flags.Inline, "inline", "i", false, "sort the resources in the input file(s) in place")
 	cmd.PersistentFlags().StringVarP(&flags.OutputDir, "output-dir", "o", "", "output the results to a specific folder")
 	cmd.PersistentFlags().BoolVarP(&flags.RemoveComments, "remove-comments", "r", false, "remove comments in the sorted file(s)")
 }

--- a/internal/sort/file_system.go
+++ b/internal/sort/file_system.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -53,6 +54,25 @@ func getPathInfo(path string) (fs.FileInfo, error) {
 	}
 
 	return info, nil
+}
+
+// Get the directory info for a given target
+func getDirectory(path string) (string, error) {
+	log.WithField("path", path).Traceln("Starting getDirInfo")
+
+	info, err := getPathInfo(path)
+	if err != nil {
+		return "", err
+	}
+
+	if info.IsDir() {
+		return path, nil
+	}
+
+	fileParts := strings.Split(path, afero.FilePathSeparator)
+	dirPath := strings.Join(fileParts[:len(fileParts)-1], afero.FilePathSeparator)
+
+	return dirPath, nil
 }
 
 // getFilesInFolder returns a list of files in a folder.

--- a/internal/sort/params.go
+++ b/internal/sort/params.go
@@ -9,6 +9,7 @@ func initParams() {
 		GroupByType:    false,
 		HasHeader:      false,
 		HeaderPattern:  "",
+		Inline:         false,
 		KeepHeader:     false,
 		OutputDir:      "",
 		RemoveComments: false,


### PR DESCRIPTION
The inline command (`-i`, `--inline`) allows users to edit the files in
place instead of specifying the output directory.

This command conflicts with the group-by-type and output-dir flags as
the group-by-type will create different files based on the resource
types. The output-dir is implicitly set by the inline flag to the input
directory, so providing the output-dir would be ignored.

Signed-off-by: Dan Thagard <dthagard@gmail.com>